### PR TITLE
feat: Implement user followers/followings API, update tweet statistics

### DIFF
--- a/src/api/userApi.ts
+++ b/src/api/userApi.ts
@@ -179,6 +179,32 @@ export const unFollowUser = async (userId: string) => {
   }
 };
 
+// Get User Followings
+export const getUserFollowings =async (username:string) => {
+  try {
+    const response = await axiosInstance.get(`/user/get-user-followings/${username}`);
+    return response.data;
+  } catch (error: unknown) {
+    if (axios.isAxiosError(error)) {
+      return Promise.reject(error.response?.data)
+    }
+    return Promise.reject(error)
+  }
+}
+
+// Get User Followers
+export const getUserFollowers =async (username:string) => {
+  try {
+    const response = await axiosInstance.get(`/user/get-user-followers/${username}`);
+    return response.data;
+  } catch (error: unknown) {
+    if (axios.isAxiosError(error)) {
+      return Promise.reject(error.response?.data)
+    }
+    return Promise.reject(error)
+  }
+}
+
 // Get user Tweets
 export const getUserTweets = async (username: string) => {
   try {

--- a/src/components/middleSectionComp/Feed/HomeFeed.tsx
+++ b/src/components/middleSectionComp/Feed/HomeFeed.tsx
@@ -13,7 +13,7 @@ const HomeFeed = ({isAuthenticated}: IProps) => {
   return (
     <div className="container max-w-600px border-x">
       <HeaderComp.Header
-        pageType="home"
+        pageType="Home"
         isForYou={isForYou}
         setIsForYou={setIsForYou}
       />

--- a/src/components/middleSectionComp/Header/FollowsHeader.tsx
+++ b/src/components/middleSectionComp/Header/FollowsHeader.tsx
@@ -1,0 +1,53 @@
+import { useNavigate, useParams } from "react-router-dom";
+interface IProps {
+  followsTab: "followers" | "following";
+}
+
+const FollowsHeader = ({ followsTab }: IProps) => {
+  const username = useParams().username;
+  const navigate = useNavigate();
+
+  return (
+    <div className="sticky top-0 z-30">
+      <div className="h-auto  backdrop-blur-md bg-white/80 ">
+        <div className="flex w-full h-14">
+          <div className="w-full h-full flex col-span-2">
+            <button
+              onClick={() => {
+                navigate(`/${username}/followers`);
+              }}
+              className="flex justify-center w-full cursor-pointer hover:bg-gray-extraLight duration-150"
+            >
+              <div className="relative h-14 flex items-center w-fit">
+                <h1 className={` ${followsTab === "followers" && "font-bold"}`}>
+                  Followers
+                </h1>
+                {followsTab === "followers" && (
+                  <div className="h-1 bg-primary-base absolute bottom-0 w-full rounded-full"></div>
+                )}
+              </div>
+            </button>
+            <button
+              onClick={() => {
+                navigate(`/${username}/following`);
+              }}
+              className="flex justify-center w-full cursor-pointer hover:bg-gray-extraLight duration-150"
+            >
+              <div className="relative h-14 flex items-center w-fit">
+                <h1 className={` ${followsTab === "following" && "font-bold"}`}>
+                  Following
+                </h1>
+                {followsTab === "following" && (
+                  <div className="h-1 bg-primary-base absolute bottom-0 w-full rounded-full"></div>
+                )}
+              </div>
+            </button>
+          </div>
+        </div>
+        <hr />
+      </div>
+    </div>
+  );
+};
+
+export default FollowsHeader;

--- a/src/components/middleSectionComp/Header/Header.tsx
+++ b/src/components/middleSectionComp/Header/Header.tsx
@@ -2,23 +2,27 @@ import React from 'react'
 import HomeHeader from "./HomeHeader"
 import TweetHeader from './TweetHeader';
 import ProfileHeader from './ProfileHeader';
+import FollowsHeader from './FollowsHeader';
 
 interface Props {
-    pageType: "home" | "TweetDetails" | "Profile";
+    pageType: "Home" | "TweetDetails" | "Profile" | "Follows";
     headerTitle?: string;
     isForYou?: boolean;
     setIsForYou?: React.Dispatch<React.SetStateAction<boolean>>;
+    followsTab?: "followers" | "following";
 }
 
-const Header = ({pageType, headerTitle, isForYou, setIsForYou}: Props) => {
+const Header = ({pageType, headerTitle, isForYou, setIsForYou, followsTab}: Props) => {
     const renderHeader = () => {
       switch (pageType) {
-        case "home":
+        case "Home":
           return <HomeHeader isForYou={isForYou} setIsForYou={setIsForYou} />;
         case "TweetDetails":
           return <TweetHeader />;
         case "Profile":
           return <ProfileHeader displayName={headerTitle!} />
+        case "Follows": 
+          return <FollowsHeader followsTab={followsTab!} />
         default:
           return null;
       }

--- a/src/components/middleSectionComp/Header/ProfileHeader.tsx
+++ b/src/components/middleSectionComp/Header/ProfileHeader.tsx
@@ -28,7 +28,6 @@ const ProfileHeader = ({displayName}:IProps) => {
             <span className="text-2xl font-bold">{displayName}</span>
           </div>
         </div>
-        <hr />
       </div>
     </div>
   );

--- a/src/components/middleSectionComp/TweetCard/DetailedCard.tsx
+++ b/src/components/middleSectionComp/TweetCard/DetailedCard.tsx
@@ -12,9 +12,18 @@ import TweetActions from "./components/TweetActions";
 import TweetCard from ".";
 
 type tweetStats = {
-  replyCount: number;
-  retweetCount: number;
-  quoteCount: number;
+  replyStats: {
+    "_id": string,
+    "author": string,
+  }[];
+  retweetStats: {
+    "_id": string,
+    "author": string,
+  }[];
+  quoteStats: {
+    "_id": string,
+    "author": string,
+  }[];
 };
 
 interface IProps {
@@ -74,16 +83,17 @@ const DetailedCard = ({ tweet, isAuthenticated }: IProps) => {
                 {tweetStats && (
                   <TweetStats
                     tweet={tweet}
-                    retweetCount={tweetStats.data?.retweetCount}
-                    quoteCount={tweetStats.data?.quoteCount}
+                    retweetCount={tweetStats.data?.replyStats.length}
+                    quoteCount={tweetStats.data?.quoteStats.length}
                   />
                 )}
 
                 <TweetActions
                   pageType="TweetDetails"
                   tweet={tweet}
-                  replyCount={tweetStats.data?.replyCount}
-                  retweetCount={tweetStats.data?.retweetCount}
+                  replyStats={tweetStats.data?.replyStats!}
+                  retweetStats={tweetStats.data?.retweetStats!}
+                  quoteStats={tweetStats.data?.quoteStats!}
                   isAuthenticated={isAuthenticated}
                 />
 

--- a/src/components/middleSectionComp/TweetCard/TweetType/Quote.tsx
+++ b/src/components/middleSectionComp/TweetCard/TweetType/Quote.tsx
@@ -12,9 +12,14 @@ import {
 import TweetCard from "..";
 
 type tweetStats = {
-  replyCount: number;
-  retweetCount: number;
-  quoteCount: number;
+  replyStats: {
+    "_id": string,
+    "author": string,
+  }[];
+  retweetStats: {
+    "_id": string,
+    "author": string,
+  }[];
 };
 
 interface IProps {
@@ -81,8 +86,8 @@ const Quote = ({ tweet, isAuthenticated }: IProps) => {
                 <TweetActions
                   pageType={"home"}
                   tweet={tweet}
-                  replyCount={tweetStats.data?.replyCount}
-                  retweetCount={tweetStats.data?.retweetCount}
+                  replyStats={tweetStats.data?.replyStats!}
+                  retweetStats={tweetStats.data?.retweetStats!}
                   isAuthenticated={isAuthenticated}
                 />
               )}

--- a/src/components/middleSectionComp/TweetCard/TweetType/Retweet.tsx
+++ b/src/components/middleSectionComp/TweetCard/TweetType/Retweet.tsx
@@ -12,19 +12,21 @@ import {
 } from "@components/middleSectionComp/TweetCard/components";
 
 type tweetStats = {
-  replyCount: number;
-  retweetCount: number;
-  quoteCount: number;
+  replyStats: {
+    "_id": string,
+    "author": string,
+  }[];
+  retweetStats: {
+    "_id": string,
+    "author": string,
+  }[];
 };
 
 interface IProps {
   tweet: ITweet;
   isAuthenticated: boolean;
 }
-const Retweet = ({
-  tweet,
-  isAuthenticated,
-}: IProps) => {
+const Retweet = ({ tweet, isAuthenticated }: IProps) => {
   const navigate = useNavigate();
 
   const originalTweetStats = useQuery<tweetStats>({
@@ -69,8 +71,9 @@ const Retweet = ({
                 <TweetActions
                   pageType={"home"}
                   tweet={tweet.originalTweet!}
-                  replyCount={originalTweetStats.data?.replyCount}
-                  retweetCount={originalTweetStats.data?.retweetCount}
+                  retweetId={tweet._id}
+                  replyStats={originalTweetStats.data?.replyStats!}
+                  retweetStats={originalTweetStats.data?.retweetStats!}
                   isAuthenticated={isAuthenticated}
                 />
               )}

--- a/src/components/middleSectionComp/TweetCard/TweetType/Tweet.tsx
+++ b/src/components/middleSectionComp/TweetCard/TweetType/Tweet.tsx
@@ -12,9 +12,14 @@ import {
 import TweetCard from "..";
 
 type tweetStats = {
-  replyCount: number;
-  retweetCount: number;
-  quoteCount: number;
+  replyStats: {
+    "_id": string,
+    "author": string,
+  }[];
+  retweetStats: {
+    "_id": string,
+    "author": string,
+  }[];
 };
 
 interface IProps {
@@ -105,8 +110,8 @@ const Tweet = ({ tweet, hideActions, isReply, isAuthenticated }: IProps) => {
                   <TweetActions
                     pageType={"home"}
                     tweet={tweet}
-                    replyCount={tweetStats.data?.replyCount}
-                    retweetCount={tweetStats.data?.retweetCount}
+                    replyStats={tweetStats.data?.replyStats!}
+                    retweetStats={tweetStats.data?.retweetStats!}
                     isAuthenticated={isAuthenticated}
                   />
                 )}

--- a/src/components/middleSectionComp/TweetCard/components/TweetActions.tsx
+++ b/src/components/middleSectionComp/TweetCard/components/TweetActions.tsx
@@ -23,15 +23,27 @@ import useToast from "@hooks/useToast";
 interface Props {
   pageType: "home" | "TweetDetails";
   tweet: ITweet;
-  replyCount?: number;
-  retweetCount?: number;
+  replyStats: {
+    _id: string;
+    author: string;
+  }[];
+  retweetStats: {
+    _id: string;
+    author: string;
+  }[];
+  quoteStats?: {
+    _id: string;
+    author: string;
+  }[];
+  retweetId?: string;
   isAuthenticated: boolean;
 }
 
 const TweetActions = ({
   tweet,
-  replyCount,
-  retweetCount,
+  replyStats,
+  retweetStats,
+  retweetId,
   pageType,
   isAuthenticated,
 }: Props) => {
@@ -47,6 +59,7 @@ const TweetActions = ({
     },
     onSuccess: () => {
       queryClient.invalidateQueries(["tweet", tweet._id]);
+      retweetId && queryClient.invalidateQueries(["tweet", retweetId]);
     },
   });
 
@@ -59,9 +72,9 @@ const TweetActions = ({
     },
     onSuccess: () => {
       queryClient.invalidateQueries(["tweet", tweet._id]);
-    }
+      retweetId && queryClient.invalidateQueries(["tweet", retweetId]);
+    },
   });
-
 
   const reduxUser = useSelector((state: RootState) => state.user);
   const [composerMode, setComposerMode] = useState<"reply" | "quote">("reply");
@@ -134,9 +147,9 @@ const TweetActions = ({
             </div>
             <div className="inline-flex  group-hover:text-primary-base">
               <span className="px-3 text-sm">
-                {replyCount! > 0 &&
+                {replyStats?.length! > 0 &&
                   pageType === "home" &&
-                  formatNumber(replyCount!)}
+                  formatNumber(replyStats?.length!)}
               </span>
             </div>
           </div>
@@ -152,13 +165,24 @@ const TweetActions = ({
           <div className="flex flex-row">
             <div className="inline-flex relative text-gray-dark group-hover:text-green-base duration-150">
               <div className="absolute -m-2 group-hover:bg-green-extraLigt  duration-150 rounded-full top-0 right-0 left-0 bottom-0" />
-              <ReTweetIcon className="w-5 h-5" />
+              {retweetStats?.length > 0 ? (
+                retweetStats?.map((retweet) => {
+                  if (retweet.author === reduxUser.user?._id) {
+                    return (
+                      <ReTweetIcon className={"w-5 h-5 text-green-base"} />
+                    );
+                  }
+                  return <ReTweetIcon className={"w-5 h-5"} />;
+                })
+              ) : (
+                <ReTweetIcon className={"w-5 h-5"} />
+              )}
             </div>
             <div className="inline-flex group-hover:text-green-base">
               <span className="px-3 text-sm">
-                {retweetCount! > 0 &&
+                {retweetStats?.length! > 0 &&
                   pageType === "home" &&
-                  formatNumber(retweetCount!)}
+                  formatNumber(retweetStats?.length!)}
               </span>
             </div>
           </div>

--- a/src/components/middleSectionComp/TweetCard/components/TweetContent.tsx
+++ b/src/components/middleSectionComp/TweetCard/components/TweetContent.tsx
@@ -36,7 +36,7 @@ const TweetContent = ({ tweet, pageType }: Props) => {
         )}
       </div>
       <div>
-        {tweet?.media && <TweetMedia tweet={tweet} />}
+        {tweet?.media?.length! > 0 && <TweetMedia tweet={tweet} />}
       </div>
     </div>
   );

--- a/src/components/middleSectionComp/UserProfile/Follows/Followers.tsx
+++ b/src/components/middleSectionComp/UserProfile/Follows/Followers.tsx
@@ -1,0 +1,111 @@
+import { useNavigate, useParams } from "react-router-dom";
+import { useSelector } from "react-redux";
+import { RootState } from "redux/config/store";
+import { getUserFollowers } from "api/userApi";
+import { useQuery } from "@tanstack/react-query";
+import { IUser } from "@customTypes/UserTypes";
+import { LoadingIcon, RetryIcon, VerifiedIcon } from "@icons/Icon";
+import FollowUnfollow from "../UserCard/UserActions/FollowUnfollow";
+import { Avatar } from "@components/middleSectionComp/TweetCard/components";
+
+const Followers = () => {
+  const username = useParams().username;
+  const navigate = useNavigate();
+
+  const reduxUser = useSelector((state: RootState) => state.user);
+
+  const followersQuery = useQuery<IUser[]>({
+    queryKey: ["followers", username],
+    queryFn: () => getUserFollowers(username!),
+    retry: false,
+    refetchOnWindowFocus: false,
+  });
+
+  console.log(followersQuery.data);
+
+  if (followersQuery.isLoading) {
+    return (
+      <div className="flex w-full mt-20 items-center justify-center">
+        <LoadingIcon />
+      </div>
+    );
+  }
+
+  if (followersQuery.isError) {
+    return (
+      <div className="flex flex-col max-w-600px w-full justify-center items-center py-5 px-3">
+        <span className="mb-5 text-center">
+          Something went wrong. Try reloading.
+        </span>
+        <button
+          onClick={() => followersQuery.refetch()}
+          className="flex gap-1 items-center px-4 py-2 min-h-[36px] bg-primary-base hover:bg-primary-dark duration-200 rounded-full"
+        >
+          <RetryIcon className="w-6 h-6 text-white" />
+          <span className="font-bold text-white">Retry</span>
+        </button>
+      </div>
+    );
+  }
+
+  if (followersQuery.data.length > 0) {
+    return (
+      <div>
+        {followersQuery.data?.map((user: IUser) => {
+          return (
+            <div key={user._id} className="flex flex-col w-full">
+              <div
+                onClick={() => navigate(`/${user.username}`)}
+                className="cursor-pointer py-3 px-4 hover:bg-gray-tweetHover duration-200"
+              >
+                <div className="flex flex-row ">
+                  <Avatar avatar={user.avatar!} username={username!} />
+
+                  <div className="flex flex-col w-full">
+                    <div className="flex flex-row w-full justify-between items-center">
+                      <div className="flex flex-col text-left">
+                        <span className="flex items-center gap-1 font-bold">
+                          {user.displayName}
+                          {user.isVerified && (
+                            <VerifiedIcon className="w-5 h-5 mt-1 text-primary-base" />
+                          )}
+                        </span>
+                        <span className="">@{user.username}</span>
+                      </div>
+                      <div>
+                        {user._id !== reduxUser.user._id && (
+                          <FollowUnfollow user={user} reduxUser={reduxUser} />
+                        )}
+                      </div>
+                    </div>
+
+                    <div className="text-left pt-1">
+                      <span className="whitespace-pre-line">{user.bio}</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex p-8 justify-center">
+      <div className="flex flex-col max-w-sm">
+        <img
+          src="https://twitter-clone.fra1.cdn.digitaloceanspaces.com/not-found-images/yellow-birds-power-line-800x400.v1.0891edb9.png"
+          alt=""
+        />
+        <span className="text-3xl font-bold mb-2">
+            Looking for followers?
+        </span>
+        <span>When someone follows this account, they’ll show up here. Tweeting and interacting with others helps boost followers.</span>
+      </div>
+    </div>
+  );
+};
+
+export default Followers;

--- a/src/components/middleSectionComp/UserProfile/Follows/Following.tsx
+++ b/src/components/middleSectionComp/UserProfile/Follows/Following.tsx
@@ -1,0 +1,105 @@
+import { useNavigate, useParams } from "react-router-dom";
+import { useSelector } from "react-redux";
+import { RootState } from "redux/config/store";
+import { getUserFollowings } from "api/userApi";
+import { useQuery } from "@tanstack/react-query";
+import { IUser } from "@customTypes/UserTypes";
+import { LoadingIcon, RetryIcon, VerifiedIcon } from "@icons/Icon";
+import FollowUnfollow from "../UserCard/UserActions/FollowUnfollow";
+import { Avatar } from "@components/middleSectionComp/TweetCard/components";
+
+const Following = () => {
+  const username = useParams().username;
+  const navigate = useNavigate();
+
+  const reduxUser = useSelector((state: RootState) => state.user);
+
+  const followingsQuery = useQuery<IUser[]>({
+    queryKey: ["followings", username],
+    queryFn: () => getUserFollowings(username!),
+    retry: false,
+    refetchOnWindowFocus: false,
+  });
+
+  console.log(followingsQuery.data);
+
+  if (followingsQuery.isLoading) {
+    return (
+      <div className="flex w-full mt-20 items-center justify-center">
+        <LoadingIcon />
+      </div>
+    );
+  }
+
+  if (followingsQuery.isError) {
+    return (
+      <div className="flex flex-col max-w-600px w-full justify-center items-center py-5 px-3">
+        <span className="mb-5 text-center">
+          Something went wrong. Try reloading.
+        </span>
+        <button
+          onClick={() => followingsQuery.refetch()}
+          className="flex gap-1 items-center px-4 py-2 min-h-[36px] bg-primary-base hover:bg-primary-dark duration-200 rounded-full"
+        >
+          <RetryIcon className="w-6 h-6 text-white" />
+          <span className="font-bold text-white">Retry</span>
+        </button>
+      </div>
+    );
+  }
+
+  if (followingsQuery.data.length > 0) {
+    return (
+      <div>
+        {followingsQuery.data?.map((user: IUser) => {
+          return (
+            <div key={user._id} className="flex flex-col w-full">
+              <div
+                onClick={() => navigate(`/${user.username}`)}
+                className="cursor-pointer py-3 px-4 hover:bg-gray-tweetHover duration-200"
+              >
+                <div className="flex flex-row ">
+                  <Avatar avatar={user.avatar!} username={username!} />
+
+                  <div className="flex flex-col w-full">
+                    <div className="flex flex-row w-full justify-between items-center">
+                      <div className="flex flex-col text-left">
+                        <span className="flex items-center gap-1 font-bold">
+                          {user.displayName}
+                          {user.isVerified && (
+                            <VerifiedIcon className="w-5 h-5 mt-1 text-primary-base" />
+                          )}
+                        </span>
+                        <span className="">@{user.username}</span>
+                      </div>
+                      <div>
+                        {user._id !== reduxUser.user._id && (
+                          <FollowUnfollow user={user} reduxUser={reduxUser} />
+                        )}
+                      </div>
+                    </div>
+
+                    <div className="text-left pt-1">
+                      <span className="whitespace-pre-line">{user.bio}</span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex p-8 justify-center">
+      <div className="flex flex-col max-w-sm">
+        <span className="text-3xl font-bold">@{username} hasn't followed</span>
+        <span>When they do, their Tweets will show up here.</span>
+      </div>
+    </div>
+  );
+};
+
+export default Following;

--- a/src/components/middleSectionComp/UserProfile/Follows/index.tsx
+++ b/src/components/middleSectionComp/UserProfile/Follows/index.tsx
@@ -1,0 +1,49 @@
+import { useParams } from "react-router-dom";
+import { useQuery } from "@tanstack/react-query";
+import { IUser } from "@customTypes/UserTypes";
+import { HeaderComp } from "@components/middleSectionComp";
+import { getUser } from "api/userApi";
+import Followers from "./Followers";
+import Following from "./Following";
+
+interface IProps {
+  isAuthenticated: boolean;
+  followsTab: "following" | "followers";
+}
+
+const Follows = ({ isAuthenticated, followsTab }: IProps) => {
+  const username = useParams().username;
+
+  const userQuery = useQuery<IUser>({
+    queryKey: ["user", username],
+    queryFn: () => getUser(username!),
+    retry: false,
+    refetchOnWindowFocus: false,
+  });
+
+  const renderFollowsUsers = () => {
+    switch (followsTab) {
+      case "followers":
+        return <Followers />;
+      case "following":
+        return <Following />;
+      default:
+        break;
+    }
+  };
+
+  return (
+    <div className="container max-w-600px w-full border-x">
+      <HeaderComp.Header
+        pageType="Profile"
+        headerTitle={userQuery.data ? userQuery.data.displayName : "Profile"}
+      />
+      
+      <HeaderComp.Header pageType="Follows" followsTab={followsTab} />
+
+      {renderFollowsUsers()}
+    </div>
+  );
+};
+
+export default Follows;

--- a/src/components/middleSectionComp/UserProfile/UserCard/UserActions/FollowUnfollow.tsx
+++ b/src/components/middleSectionComp/UserProfile/UserCard/UserActions/FollowUnfollow.tsx
@@ -36,6 +36,7 @@ const FollowUnfollow = ({ user, reduxUser }: IProps) => {
   });
 
   const handleFollowClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
     if (reduxUser.user.following?.includes(user._id)) {
       unFollowUserQuery.mutate(user._id);
     } else {

--- a/src/components/middleSectionComp/UserProfile/UserCard/UserInfo.tsx
+++ b/src/components/middleSectionComp/UserProfile/UserCard/UserInfo.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { LocationIcon, BirthIcon, WebsiteIcon, CalendarIcon } from "@icons/Icon";
 import { formatDate, getMonthNameFromNumber } from "utils";
 import { IUser } from "@customTypes/UserTypes";
@@ -40,14 +39,14 @@ const UserInfo = ({ user }: IProps) => {
         </div>
       </div>
       <div className="flex flex-row gap-5">
-        <div className="flex flex-row gap-1 cursor-pointer hover:underline underline-offset-auto">
+        <a href={`/${user.username}/following`} className="flex flex-row gap-1 cursor-pointer hover:underline underline-offset-auto">
           <span className="font-bold">{user.following.length}</span>
           <span>Following</span>
-        </div>
-        <div className="flex flex-row gap-1 cursor-pointer hover:underline underline-offset-auto">
+        </a>
+        <a href={`/${user.username}/followers`} className="flex flex-row gap-1 cursor-pointer hover:underline underline-offset-auto">
           <span className="font-bold">{user.followers.length}</span>
           <span>Followers</span>
-        </div>
+        </a>
       </div>
       {/* website info */}
       {user.website && (

--- a/src/components/middleSectionComp/UserProfile/index.ts
+++ b/src/components/middleSectionComp/UserProfile/index.ts
@@ -1,2 +1,3 @@
 export {default as UserProfile} from "./UserProfile"
+export {default as Follows} from "./Follows"
 export * as UserCardComp from "./UserCard"

--- a/src/layout/FollowsLayout.tsx
+++ b/src/layout/FollowsLayout.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+import { RightSidebar, LeftSideBar } from "@components/index";
+import {Follows} from "@components/middleSectionComp/UserProfile"
+
+interface IProps {
+  isAuthenticated: boolean;
+  followsTab: "followers" | "following"
+}
+
+const FollowsLayout = ({ isAuthenticated, followsTab }: IProps) => {
+  return (
+    <div>
+      <div className="flex min-h-screen max-w-7xl mx-auto sticky">
+        <LeftSideBar />
+        <div className="flex flex-row gap-5 min-h-full w-full">
+          <Follows isAuthenticated={isAuthenticated} followsTab={followsTab} />
+          <RightSidebar isAuthenticated={isAuthenticated} />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default FollowsLayout;

--- a/src/layout/UserProfileLayout.tsx
+++ b/src/layout/UserProfileLayout.tsx
@@ -1,12 +1,11 @@
-import React from 'react'
-import { useSelector } from "react-redux";
-import { RootState } from "@redux/config/store";
-import { UserProfileComp } from '@components/middleSectionComp'
-import { RightSidebar, LeftSideBar } from '@components/index'
+import { UserProfileComp } from "@components/middleSectionComp";
+import { RightSidebar, LeftSideBar } from "@components/index";
 
-const UserProfileLayout = () => {
-  const isAuthenticated = useSelector((state: RootState) => state.user.isAuthenticated);
+interface IProps {
+  isAuthenticated: boolean;
+}
 
+const UserProfileLayout = ({ isAuthenticated }: IProps) => {
   return (
     <div className="flex min-h-screen max-w-7xl mx-auto sticky">
       <LeftSideBar />
@@ -15,7 +14,7 @@ const UserProfileLayout = () => {
         <RightSidebar isAuthenticated={isAuthenticated} />
       </div>
     </div>
-  )
-}
+  );
+};
 
-export default UserProfileLayout
+export default UserProfileLayout;

--- a/src/layout/index.ts
+++ b/src/layout/index.ts
@@ -1,3 +1,4 @@
 export {default as HomeLayout} from "./HomeLayout"
 export {default as TweetDetailsLayout} from "./TweetDetailsLayout"
 export {default as UserProfileLayout} from "./UserProfileLayout"
+export {default as FollowsLayout} from "./FollowsLayout"

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -4,7 +4,7 @@ import PrivateRoute from './PrivateRoute'; // for ignore the authenticated users
 import { Navigate } from 'react-router-dom';
 import { AuthModal } from '@components/auth';
 import Logout from '@components/auth/Logout';
-import { HomeLayout, TweetDetailsLayout, UserProfileLayout } from "@layout/index";
+import { HomeLayout, TweetDetailsLayout, UserProfileLayout, FollowsLayout } from "@layout/index";
 
 interface IAppRoutes {
     isAuthenticated: boolean;
@@ -72,17 +72,26 @@ const AppRoutes = ({isAuthenticated}:IAppRoutes) => {
         />
         <Route
           path="/:username"
-          element={<UserProfileLayout />}
+          element={<UserProfileLayout isAuthenticated={isAuthenticated} />}
         />
         
         <Route
           path="/:username/:tab"
-          element={<UserProfileLayout />}
+          element={<UserProfileLayout isAuthenticated={isAuthenticated} />}
         />
 
         <Route
           path="/:username/status/:tweetId"
           element={<TweetDetailsLayout />}
+        />
+
+        <Route
+          path='/:username/followers'
+          element={<FollowsLayout isAuthenticated={isAuthenticated} followsTab='followers' />}
+        />
+        <Route
+          path='/:username/following'
+          element={<FollowsLayout isAuthenticated={isAuthenticated} followsTab='following' />}
         />
       </Routes>
   )

--- a/src/types/TweetTypes.d.ts
+++ b/src/types/TweetTypes.d.ts
@@ -14,9 +14,6 @@ export interface ITweet {
   whoCanReply: "everyone" | "following" | "mentioned";
   content?: string;
   media?: Media[];
-  replyCount?: number;
-  retweetCount?: number;
-  quoteCount?: number;
   likes?: string[];
   bookmarks?: string[];
   originalTweet?: ITweet;


### PR DESCRIPTION
~ Added API to fetch user followers and followings.
~ Created new routes, layout and corresponding components to display user followers and followings.
~ A new header was created for tab switching between followers and followings.
~ Included author ID in tweet statistics for checking user interactions on a tweet (retweet).
~ Updated other components affected by changes in tweet statistics.
~ Fixed issue with real-time updates when like/unlike a retweeted tweet.