### PR TITLE
feat: add limited API for 'who to follow' and update related components

### DIFF
--- a/src/api/userApi.ts
+++ b/src/api/userApi.ts
@@ -153,6 +153,16 @@ export const searchUser = async (username: string) => {
   }
 };
 
+// Suggest new users
+export const whoToFollow = async (limit: number) => {
+  try {
+    const response = await axiosInstance.get(`/user/who-to-follow/${limit}`);
+    return response.data;
+  } catch (error: unknown) {
+    return Promise.reject(error);
+  }
+};
+
 // Follow User
 export const followUser = async (userId: string) => {
   try {

--- a/src/components/middleSectionComp/TweetCard/components/Avatar.tsx
+++ b/src/components/middleSectionComp/TweetCard/components/Avatar.tsx
@@ -20,7 +20,7 @@ const Avatar = ({ avatar, username }: Props) => {
         <img
           src={avatar}
           alt="profile"
-          className="w-11 h-11 cursor-pointer object-cover hover:brightness-90 rounded-full"
+          className="w-10 h-10 cursor-pointer object-cover hover:brightness-90 rounded-full"
         />
       </div>
       

--- a/src/components/middleSectionComp/TweetCard/components/TweetActions.tsx
+++ b/src/components/middleSectionComp/TweetCard/components/TweetActions.tsx
@@ -115,7 +115,7 @@ const TweetActions = ({
   });
 
   return (
-    <div>
+    <div key={tweet._id}>
       {showReplyModal && isAuthenticated && (
         <DigalogModals.ReplyQuoteModal
           composerMode={composerMode}
@@ -134,7 +134,7 @@ const TweetActions = ({
         />
       )}
 
-      <div className={actionClasses}>
+      <div key={tweet._id} className={actionClasses}>
         <button
           onClick={handleIconClick}
           name="reply"
@@ -166,13 +166,13 @@ const TweetActions = ({
             <div className="inline-flex relative text-gray-dark group-hover:text-green-base duration-150">
               <div className="absolute -m-2 group-hover:bg-green-extraLigt  duration-150 rounded-full top-0 right-0 left-0 bottom-0" />
               {retweetStats?.length > 0 ? (
-                retweetStats?.map((retweet) => {
+                retweetStats?.map((retweet, index) => {
                   if (retweet.author === reduxUser.user?._id) {
                     return (
-                      <ReTweetIcon className={"w-5 h-5 text-green-base"} />
+                      <ReTweetIcon key={index} className={"w-5 h-5 text-green-base"} />
                     );
                   }
-                  return <ReTweetIcon className={"w-5 h-5"} />;
+                  return <ReTweetIcon key={index} className={"w-5 h-5"} />;
                 })
               ) : (
                 <ReTweetIcon className={"w-5 h-5"} />

--- a/src/components/middleSectionComp/UserProfile/Follows/Followers.tsx
+++ b/src/components/middleSectionComp/UserProfile/Follows/Followers.tsx
@@ -73,9 +73,7 @@ const Followers = () => {
                         <span className="">@{user.username}</span>
                       </div>
                       <div>
-                        {user._id !== reduxUser.user._id && (
-                          <FollowUnfollow user={user} reduxUser={reduxUser} />
-                        )}
+                        <FollowUnfollow user={user} reduxUser={reduxUser} />
                       </div>
                     </div>
 

--- a/src/components/middleSectionComp/UserProfile/Follows/Following.tsx
+++ b/src/components/middleSectionComp/UserProfile/Follows/Following.tsx
@@ -73,9 +73,7 @@ const Following = () => {
                         <span className="">@{user.username}</span>
                       </div>
                       <div>
-                        {user._id !== reduxUser.user._id && (
-                          <FollowUnfollow user={user} reduxUser={reduxUser} />
-                        )}
+                        <FollowUnfollow user={user} reduxUser={reduxUser} />
                       </div>
                     </div>
 

--- a/src/components/middleSectionComp/UserProfile/UserCard/UserActions/FollowUnfollow.tsx
+++ b/src/components/middleSectionComp/UserProfile/UserCard/UserActions/FollowUnfollow.tsx
@@ -68,6 +68,10 @@ const FollowUnfollow = ({ user, reduxUser }: IProps) => {
     "min-h-[36px] h-full px-4 bg-black text-white font-bold border rounded-full duration-200"
   );
 
+  if(reduxUser.user._id === user._id) {
+    return null;
+  }
+
   return (
     <div>
       {reduxUser.user.following.includes(user._id) ? (

--- a/src/components/rightSidebarComp/RightSidebar.tsx
+++ b/src/components/rightSidebarComp/RightSidebar.tsx
@@ -59,33 +59,6 @@ const RightSidebar = ({ isAuthenticated }: IProps) => {
     },
   ];
 
-  type Account = {
-    name: string;
-    username: string;
-    avatar: string;
-  };
-
-  const whoToFollows: Account[] = [
-    {
-      name: "Account 1",
-      username: "@account1",
-      avatar:
-        "https://pbs.twimg.com/profile_images/1552608564371460098/cfJ8z7zb_400x400.jpg",
-    },
-    {
-      name: "Account 2",
-      username: "@account2",
-      avatar:
-        "https://pbs.twimg.com/profile_images/1525224493127544832/MWJSwspp_400x400.jpg",
-    },
-    {
-      name: "Account 3",
-      username: "@account3",
-      avatar:
-        "https://pbs.twimg.com/profile_images/1634576243747069956/3E3yRyhL_400x400.jpg",
-    },
-  ];
-
   return (
     <aside className="max-w-350px min-w-290px mr-10px hidden md:inline-block right-sidebar overflow-y-auto">
       <div className="flex flex-col relative h-full min-h-510px">
@@ -117,27 +90,7 @@ const RightSidebar = ({ isAuthenticated }: IProps) => {
                 </a>
               </div>
               {/* account suggestion */}
-              <div className="mt-5 bg-gray-rightbar rounded-2xl m-3">
-                <div className="p-3">
-                  <span className="text-xl font-bold">Who to follow</span>
-                </div>
-                <div className=" flex flex-col">
-                  {whoToFollows.map((account) => (
-                    <WhoToFollow
-                      key={account.username}
-                      name={account.name}
-                      username={account.username}
-                      avatar={account.avatar}
-                    />
-                  ))}
-                </div>
-                <a
-                  href="/"
-                  className="flex flex-col hover:bg-gray-trendsHover rounded-b-2xl px-3 py-4 duration-100"
-                >
-                  <span className="text-primary-base">Show More</span>
-                </a>
-              </div>
+              <WhoToFollow />
             </div>
           </div>
         ) : (


### PR DESCRIPTION
This commit includes several updates:
~ A new API endpoint that provides a limited number of users for the 'Who to Follow' section, specifically showing new members. ~ Fixed the unique key issue in TweetActions.
~ Updated the user follow button to prevent it from appearing on the user's own account. ~ The 'Who to Follow' section now recommends three new registered users.