### PR TITLE
improvement: HomeFeed persistence and TweetActions

### DIFF
--- a/src/components/middleSectionComp/Feed/HomeFeed.tsx
+++ b/src/components/middleSectionComp/Feed/HomeFeed.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { HeaderComp } from "@components/middleSectionComp";
 import { TweetComposer } from "../ComposerComp";
 import FollowingFeed from "./FollowingFeed";
@@ -9,8 +9,13 @@ interface IProps {
 }
 
 const HomeFeed = ({isAuthenticated}: IProps) => {
-  const [isForYou, setIsForYou] = useState(true);
+  const localIsForYou = localStorage.getItem("isForYou");
+  const [isForYou, setIsForYou] = useState(localIsForYou !== null ? JSON.parse(localIsForYou) : true);
   
+  useEffect(() => {
+    localStorage.setItem("isForYou", JSON.stringify(isForYou));
+  }, [isForYou]);
+
   return (
     <div className="container max-w-600px border-x">
       <HeaderComp.Header

--- a/src/components/middleSectionComp/TweetCard/DetailedCard.tsx
+++ b/src/components/middleSectionComp/TweetCard/DetailedCard.tsx
@@ -36,7 +36,6 @@ const DetailedCard = ({ tweet, isAuthenticated }: IProps) => {
     queryKey: ["tweetStats", tweet._id],
     queryFn: () => getSpecificTweetStats(tweet._id),
   });
-  console.log(tweet.originalTweet);
   
   return (
     <div>

--- a/src/components/middleSectionComp/TweetCard/components/ActionComponents/BookmarkAction.tsx
+++ b/src/components/middleSectionComp/TweetCard/components/ActionComponents/BookmarkAction.tsx
@@ -1,0 +1,16 @@
+import { BookmarksIcon } from "@icons/Icon";
+
+const BookmarkAction = () => {
+  return (
+    <button title="Bookmark" className="group h-5 min-h-max">
+      <div className="flex flex-row">
+        <div className="inline-flex relative text-gray-dark group-hover:text-primary-base duration-150">
+          <div className="absolute -m-2 group-hover:bg-primary-hover duration-150 rounded-full top-0 right-0 left-0 bottom-0"></div>
+          <BookmarksIcon isActive={false} className={"w-5 h-5"} />
+        </div>
+      </div>
+    </button>
+  );
+};
+
+export default BookmarkAction;

--- a/src/components/middleSectionComp/TweetCard/components/ActionComponents/LikeAction.tsx
+++ b/src/components/middleSectionComp/TweetCard/components/ActionComponents/LikeAction.tsx
@@ -1,0 +1,91 @@
+import { ITweet } from "@customTypes/TweetTypes";
+import { LikeIcon, LikedIcon } from "@icons/Icon";
+import { UserState } from "@redux/slices/userSlice";
+import { formatNumber } from "@utils/formatNumber";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { likeTweet, unlikeTweet } from "api/tweetApi";
+import { PersistPartial } from "redux-persist/es/persistReducer";
+import useToast from "@hooks/useToast";
+
+interface IProps {
+  isAuthenticated: boolean;
+  reduxUser: UserState & PersistPartial;
+  tweet: ITweet;
+  retweetId?: string;
+  pageType: "home" | "TweetDetails";
+}
+
+const LikeAction = ({
+  isAuthenticated,
+  reduxUser,
+  tweet,
+  retweetId,
+  pageType,
+}: IProps) => {
+  const queryClient = useQueryClient();
+
+  const { showToast } = useToast();
+
+  const likeMutation = useMutation({
+    mutationKey: ["likeTweet", tweet._id],
+    mutationFn: likeTweet,
+    onError: (err: any) => {
+      console.log(err);
+      showToast(err?.message || "error", "error");
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries(["tweet", tweet._id]);
+      retweetId && queryClient.invalidateQueries(["tweet", retweetId]);
+    },
+  });
+
+  const unlikeMutation = useMutation({
+    mutationKey: ["unlikeTweet", tweet._id],
+    mutationFn: unlikeTweet,
+    onError: (err: any) => {
+      console.log(err);
+      showToast(err?.message || "error", "error");
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries(["tweet", tweet._id]);
+      retweetId && queryClient.invalidateQueries(["tweet", retweetId]);
+    },
+  });
+
+  return (
+    <button
+      title="Like"
+      onClick={(e) => {
+        e.stopPropagation();
+        if (isAuthenticated) {
+          if (tweet.likes?.includes(reduxUser.user?._id)) {
+            unlikeMutation.mutate(tweet._id);
+          } else {
+            likeMutation.mutate(tweet._id);
+          }
+        }
+      }}
+      className="group h-5 min-h-max"
+    >
+      <div className="flex flex-row">
+        <div className="inline-flex relative text-gray-dark group-hover:text-red-base duration-150">
+          <div className="absolute -m-2 group-hover:bg-red-extraLight duration-150 rounded-full top-0 right-0 left-0 bottom-0"></div>
+          {tweet.likes?.includes(reduxUser.user?._id) ? (
+            <LikedIcon className={"w-5 h-5 fill-red-removeText"} />
+          ) : (
+            <LikeIcon className={"w-5 h-5"} />
+          )}
+        </div>
+        <div className="inline-flex  group-hover:text-red-base">
+          <span className="px-3 text-sm">
+            {tweet?.likes!.length! > 0 &&
+              pageType === "home" &&
+              formatNumber(tweet.likes!.length)}
+          </span>
+        </div>
+      </div>
+    </button>
+  );
+};
+
+export default LikeAction;

--- a/src/components/middleSectionComp/TweetCard/components/ActionComponents/ReplyAction.tsx
+++ b/src/components/middleSectionComp/TweetCard/components/ActionComponents/ReplyAction.tsx
@@ -1,0 +1,61 @@
+import React, { useState } from "react";
+import { DigalogModals } from "@components/middleSectionComp";
+import { ITweet } from "@customTypes/TweetTypes";
+import { ReplyIcon } from "@icons/Icon";
+import { formatNumber } from "@utils/formatNumber";
+
+interface IProps {
+  isAuthenticated: boolean;
+  tweet: ITweet;
+  pageType: "home" | "TweetDetails";
+  replyStats: {
+    _id: string;
+    author: string;
+  }[];
+}
+
+const ReplyAction = ({
+  isAuthenticated,
+  tweet,
+  pageType,
+  replyStats,
+}: IProps) => {
+  const [showReplyModal, setReplyModal] = useState(false);
+
+  return (
+    <div>
+      {showReplyModal && isAuthenticated && (
+        <DigalogModals.ReplyQuoteModal
+          composerMode={"reply"}
+          tweet={tweet}
+          isOpen={showReplyModal}
+          onClose={() => setReplyModal(false)}
+        />
+      )}
+      <button
+        title="Reply"
+        onClick={(e) => {
+          e.stopPropagation();
+          setReplyModal(true);
+        }}
+        className="group h-5 min-h-max"
+      >
+        <div className="flex flex-row">
+          <div className=" relative text-gray-dark group-hover:text-primary-base duration-150">
+            <div className="absolute -m-2 group-hover:bg-primary-hover duration-150 rounded-full top-0 right-0 left-0 bottom-0" />
+            <ReplyIcon className={"w-5 h-5"} />
+          </div>
+          <div className="inline-flex  group-hover:text-primary-base">
+            <span className="px-3 text-sm">
+              {replyStats?.length! > 0 &&
+                pageType === "home" &&
+                formatNumber(replyStats?.length!)}
+            </span>
+          </div>
+        </div>
+      </button>
+    </div>
+  );
+};
+
+export default ReplyAction;

--- a/src/components/middleSectionComp/TweetCard/components/ActionComponents/RetweetAction.tsx
+++ b/src/components/middleSectionComp/TweetCard/components/ActionComponents/RetweetAction.tsx
@@ -1,0 +1,88 @@
+import { ReTweetIcon } from "@icons/Icon";
+import { useState } from "react";
+import { ITweet } from "@customTypes/TweetTypes";
+import { DigalogModals } from "@components/middleSectionComp";
+import { formatNumber } from "@utils/formatNumber";
+import { UserState } from "@redux/slices/userSlice";
+import { PersistPartial } from "redux-persist/es/persistReducer";
+import ReTweetMenu from "../ReTweetMenu";
+
+interface IProps {
+  isAuthenticated: boolean;
+  reduxUser: UserState & PersistPartial;
+  tweet: ITweet;
+  pageType: "home" | "TweetDetails";
+  retweetStats: {
+    _id: string;
+    author: string;
+  }[];
+}
+
+const RetweetAction = ({
+  isAuthenticated,
+  reduxUser,
+  tweet,
+  pageType,
+  retweetStats,
+}: IProps) => {
+  const [reTweetMenu, setShowRetweetMenu] = useState(false);
+  const [showQuoteModal, setShowQuotModal] = useState(false);
+
+  return (
+    <div>
+      {showQuoteModal && isAuthenticated && (
+        <DigalogModals.ReplyQuoteModal
+          composerMode={"quote"}
+          tweet={tweet}
+          isOpen={showQuoteModal}
+          onClose={() => setShowQuotModal(false)}
+        />
+      )}
+
+      <div
+        title="Retweet"
+        onClick={(e) => {
+          setShowRetweetMenu(!reTweetMenu);
+          e.stopPropagation();
+        }}
+        className="group h-5 min-h-max relative cursor-pointer"
+      >
+        <div className="flex flex-row">
+          <div className="inline-flex relative text-gray-dark group-hover:text-green-base duration-150">
+            <div className="absolute -m-2 group-hover:bg-green-extraLigt  duration-150 rounded-full top-0 right-0 left-0 bottom-0" />
+            {retweetStats?.length > 0 ? (
+              retweetStats?.map((retweet, index) => {
+                if (retweet.author === reduxUser.user?._id) {
+                  return (
+                    <ReTweetIcon
+                      key={index}
+                      className={"w-5 h-5 text-green-base"}
+                    />
+                  );
+                }
+                return <ReTweetIcon key={index} className={"w-5 h-5"} />;
+              })
+            ) : (
+              <ReTweetIcon className={"w-5 h-5"} />
+            )}
+          </div>
+          <div className="inline-flex group-hover:text-green-base">
+            <span className="px-3 text-sm">
+              {retweetStats?.length! > 0 &&
+                pageType === "home" &&
+                formatNumber(retweetStats?.length!)}
+            </span>
+          </div>
+        </div>
+        {reTweetMenu && isAuthenticated && (
+          <ReTweetMenu
+            onClose={() => setShowRetweetMenu(false)}
+            setShowQuotModal={setShowQuotModal}
+          />
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default RetweetAction;

--- a/src/components/middleSectionComp/TweetCard/components/ActionComponents/ShareAction.tsx
+++ b/src/components/middleSectionComp/TweetCard/components/ActionComponents/ShareAction.tsx
@@ -1,0 +1,42 @@
+import React, { useState } from "react";
+import { TweetCardComp } from "@components/middleSectionComp";
+import { ITweet } from "@customTypes/TweetTypes";
+import { ShareIcon } from "@icons/Icon";
+
+interface IProps {
+  tweet: ITweet;
+  isAuthenticated: boolean;
+}
+
+const ShareAction = ({ isAuthenticated, tweet }: IProps) => {
+  const [shareMenu, setShowShareMenu] = useState(false);
+  return (
+    <div
+      className="group h-5 min-h-max relative"
+      role="button"
+      onClick={(e) => {
+        e.stopPropagation();
+        setShowShareMenu(!shareMenu);
+      }}
+    >
+      <div
+        title="Share"
+        className="flex flex-row group-hover:text-primary-base duration-150"
+      >
+        <div className="inline-flex relative ">
+          <div className="absolute -m-2 group-hover:bg-primary-hover duration-150 rounded-full top-0 right-0 left-0 bottom-0 "></div>
+          <ShareIcon className={"w-5 h-5"} />
+        </div>
+      </div>
+      {shareMenu && (
+        <TweetCardComp.ShareMenu
+          onClose={() => setShowShareMenu(false)}
+          tweet={tweet}
+          isAuthenticated={isAuthenticated}
+        />
+      )}
+    </div>
+  );
+};
+
+export default ShareAction;

--- a/src/components/middleSectionComp/TweetCard/components/ActionComponents/Views.tsx
+++ b/src/components/middleSectionComp/TweetCard/components/ActionComponents/Views.tsx
@@ -1,0 +1,25 @@
+import { ITweet } from "@customTypes/TweetTypes";
+import { AnalyticsIcon } from "@icons/Icon";
+import { formatNumber } from "@utils/formatNumber";
+
+interface IProps {
+  tweet: ITweet;
+}
+
+const Views = ({ tweet }: IProps) => {
+  return (
+    <button title="View" className="group h-5 min-h-max">
+      <div className="flex flex-row">
+        <div className="inline-flex relative text-gray-dark group-hover:text-primary-base duration-150">
+          <div className="absolute -m-2 group-hover:bg-primary-hover duration-150 rounded-full top-0 right-0 left-0 bottom-0"></div>
+          <AnalyticsIcon className={"w-5 h-5"} />
+        </div>
+        <div className="inline-flex  group-hover:text-primary-base">
+          <span className="px-3 text-sm">{formatNumber(tweet?.view)}</span>
+        </div>
+      </div>
+    </button>
+  );
+};
+
+export default Views;

--- a/src/components/middleSectionComp/TweetCard/components/ReTweetMenu.tsx
+++ b/src/components/middleSectionComp/TweetCard/components/ReTweetMenu.tsx
@@ -2,12 +2,11 @@ import React, { useRef, useEffect, useCallback } from "react";
 import { ReTweetIcon } from "@icons/Icon";
 
 interface IProps {
-  setComposerMode: React.Dispatch<React.SetStateAction<"reply" | "quote">>;
-  setQuoteModal: React.Dispatch<React.SetStateAction<boolean>>;
+  setShowQuotModal: React.Dispatch<React.SetStateAction<boolean>>;
   onClose: () => void;
 }
 
-const ShareMenu = ({ onClose, setQuoteModal, setComposerMode }: IProps) => {
+const ReTweetMenu = ({ onClose, setShowQuotModal }: IProps) => {
   const menuRef = useRef<HTMLDivElement>(null);
 
   const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
@@ -19,8 +18,7 @@ const ShareMenu = ({ onClose, setQuoteModal, setComposerMode }: IProps) => {
         console.log(actionName);
         break;
       case "quote":
-        setComposerMode("quote");
-        setQuoteModal(true);
+        setShowQuotModal(true);
         break;
       default:
         break;
@@ -46,7 +44,7 @@ const ShareMenu = ({ onClose, setQuoteModal, setComposerMode }: IProps) => {
   return (
     <div
       ref={menuRef}
-      className="absolute z-10 top-0 -right-3 w-max border bg-white rounded-2xl shadow-lg"
+      className="absolute z-10 -top-2 -right-3 w-max border bg-white rounded-2xl shadow-lg"
     >
       <div className="flex flex-col">
         <button
@@ -83,4 +81,4 @@ const ShareMenu = ({ onClose, setQuoteModal, setComposerMode }: IProps) => {
   );
 };
 
-export default ShareMenu;
+export default ReTweetMenu;

--- a/src/components/middleSectionComp/TweetCard/components/TweetActions.tsx
+++ b/src/components/middleSectionComp/TweetCard/components/TweetActions.tsx
@@ -1,24 +1,13 @@
-import React, { useState } from "react";
 import classNames from "classnames";
 import { useSelector } from "react-redux";
 import { RootState } from "@redux/config/store";
-import { useMutation, useQueryClient } from "@tanstack/react-query";
-import { likeTweet, unlikeTweet } from "api/tweetApi";
-import { TweetCardComp } from "@components/middleSectionComp/index";
-import { DigalogModals } from "@components/middleSectionComp";
-import { formatNumber } from "@utils/index";
-import {
-  ReplyIcon,
-  ReTweetIcon,
-  LikeIcon,
-  AnalyticsIcon,
-  ShareIcon,
-  BookmarksIcon,
-  LikedIcon,
-} from "@icons/Icon";
 import { ITweet } from "@customTypes/TweetTypes";
-import ReTweetMenu from "./ReTweetMenu";
-import useToast from "@hooks/useToast";
+import ReplyAction from "./ActionComponents/ReplyAction";
+import RetweetAction from "./ActionComponents/RetweetAction";
+import LikeAction from "./ActionComponents/LikeAction";
+import Views from "./ActionComponents/Views";
+import ShareAction from "./ActionComponents/ShareAction";
+import BookmarkAction from "./ActionComponents/BookmarkAction";
 
 interface Props {
   pageType: "home" | "TweetDetails";
@@ -47,65 +36,7 @@ const TweetActions = ({
   pageType,
   isAuthenticated,
 }: Props) => {
-  const queryClient = useQueryClient();
-  const { showToast } = useToast();
-
-  const likeMutation = useMutation({
-    mutationKey: ["likeTweet", tweet._id],
-    mutationFn: likeTweet,
-    onError: (err: any) => {
-      console.log(err);
-      showToast(err?.message || "error", "error");
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries(["tweet", tweet._id]);
-      retweetId && queryClient.invalidateQueries(["tweet", retweetId]);
-    },
-  });
-
-  const unlikeMutation = useMutation({
-    mutationKey: ["unlikeTweet", tweet._id],
-    mutationFn: unlikeTweet,
-    onError: (err: any) => {
-      console.log(err);
-      showToast(err?.message || "error", "error");
-    },
-    onSuccess: () => {
-      queryClient.invalidateQueries(["tweet", tweet._id]);
-      retweetId && queryClient.invalidateQueries(["tweet", retweetId]);
-    },
-  });
-
   const reduxUser = useSelector((state: RootState) => state.user);
-  const [composerMode, setComposerMode] = useState<"reply" | "quote">("reply");
-
-  const [showReplyModal, setReplyModal] = useState(false);
-  const [showQuoteModal, setQuoteModal] = useState(false);
-
-  const [shareMenu, setShowShareMenu] = useState(false);
-  const [reTweetMenu, setShowRetweetMenu] = useState(false);
-
-  const handleIconClick = (e: React.MouseEvent<HTMLButtonElement>) => {
-    e.stopPropagation();
-    const actionName = e.currentTarget.name;
-
-    if (isAuthenticated) {
-      switch (actionName) {
-        case "reply":
-          setComposerMode("reply");
-          setReplyModal(true);
-          break;
-        case "like":
-          if (tweet.likes?.includes(reduxUser.user?._id)) {
-            unlikeMutation.mutate(tweet._id);
-          } else {
-            likeMutation.mutate(tweet._id);
-          }
-          break;
-        case "bookmarks":
-      }
-    }
-  };
 
   const actionClasses = classNames({
     "flex flex-row justify-between gap-2 mt-3 max-w-md w-full":
@@ -116,166 +47,37 @@ const TweetActions = ({
 
   return (
     <div key={tweet._id}>
-      {showReplyModal && isAuthenticated && (
-        <DigalogModals.ReplyQuoteModal
-          composerMode={composerMode}
-          tweet={tweet}
-          isOpen={showReplyModal}
-          onClose={() => setReplyModal(false)}
-        />
-      )}
-
-      {showQuoteModal && isAuthenticated && (
-        <DigalogModals.ReplyQuoteModal
-          composerMode={composerMode}
-          tweet={tweet}
-          isOpen={showQuoteModal}
-          onClose={() => setQuoteModal(false)}
-        />
-      )}
-
       <div key={tweet._id} className={actionClasses}>
-        <button
-          onClick={handleIconClick}
-          name="reply"
-          className="group h-5 min-h-max"
-        >
-          <div className="flex flex-row">
-            <div className=" relative text-gray-dark group-hover:text-primary-base duration-150">
-              <div className="absolute -m-2 group-hover:bg-primary-hover duration-150 rounded-full top-0 right-0 left-0 bottom-0" />
-              <ReplyIcon className={"w-5 h-5"} />
-            </div>
-            <div className="inline-flex  group-hover:text-primary-base">
-              <span className="px-3 text-sm">
-                {replyStats?.length! > 0 &&
-                  pageType === "home" &&
-                  formatNumber(replyStats?.length!)}
-              </span>
-            </div>
-          </div>
-        </button>
+        <ReplyAction
+          isAuthenticated={isAuthenticated}
+          tweet={tweet}
+          pageType={pageType}
+          replyStats={replyStats}
+        />
 
-        <div
-          onClick={(e) => {
-            setShowRetweetMenu(!reTweetMenu);
-            e.stopPropagation();
-          }}
-          className="group h-5 min-h-max relative cursor-pointer"
-        >
-          <div className="flex flex-row">
-            <div className="inline-flex relative text-gray-dark group-hover:text-green-base duration-150">
-              <div className="absolute -m-2 group-hover:bg-green-extraLigt  duration-150 rounded-full top-0 right-0 left-0 bottom-0" />
-              {retweetStats?.length > 0 ? (
-                retweetStats?.map((retweet, index) => {
-                  if (retweet.author === reduxUser.user?._id) {
-                    return (
-                      <ReTweetIcon key={index} className={"w-5 h-5 text-green-base"} />
-                    );
-                  }
-                  return <ReTweetIcon key={index} className={"w-5 h-5"} />;
-                })
-              ) : (
-                <ReTweetIcon className={"w-5 h-5"} />
-              )}
-            </div>
-            <div className="inline-flex group-hover:text-green-base">
-              <span className="px-3 text-sm">
-                {retweetStats?.length! > 0 &&
-                  pageType === "home" &&
-                  formatNumber(retweetStats?.length!)}
-              </span>
-            </div>
-          </div>
-          {reTweetMenu && isAuthenticated && (
-            <ReTweetMenu
-              onClose={() => setShowRetweetMenu(false)}
-              setComposerMode={setComposerMode}
-              setQuoteModal={setQuoteModal}
-            />
-          )}
-        </div>
+        <RetweetAction
+          isAuthenticated={isAuthenticated}
+          pageType={pageType}
+          reduxUser={reduxUser}
+          retweetStats={retweetStats}
+          tweet={tweet}
+        />
 
-        <button
-          onClick={handleIconClick}
-          name="like"
-          className="group h-5 min-h-max"
-        >
-          <div className="flex flex-row">
-            <div className="inline-flex relative text-gray-dark group-hover:text-red-base duration-150">
-              <div className="absolute -m-2 group-hover:bg-red-extraLight duration-150 rounded-full top-0 right-0 left-0 bottom-0"></div>
-              {tweet.likes?.includes(reduxUser.user?._id) ? (
-                <LikedIcon className={"w-5 h-5 fill-red-removeText"} />
-              ) : (
-                <LikeIcon className={"w-5 h-5"} />
-              )}
-            </div>
-            <div className="inline-flex  group-hover:text-red-base">
-              <span className="px-3 text-sm">
-                {tweet?.likes!.length! > 0 &&
-                  pageType === "home" &&
-                  formatNumber(tweet.likes!.length)}
-              </span>
-            </div>
-          </div>
-        </button>
+        <LikeAction
+          isAuthenticated={isAuthenticated}
+          tweet={tweet}
+          pageType={pageType}
+          reduxUser={reduxUser}
+          retweetId={retweetId}
+        />
 
         {pageType === "TweetDetails" && (
-          <button
-            onClick={handleIconClick}
-            name="bookmarks"
-            className="group h-5 min-h-max"
-          >
-            <div className="flex flex-row">
-              <div className="inline-flex relative text-gray-dark group-hover:text-primary-base duration-150">
-                <div className="absolute -m-2 group-hover:bg-primary-hover duration-150 rounded-full top-0 right-0 left-0 bottom-0"></div>
-                <BookmarksIcon isActive={false} className={"w-5 h-5"} />
-              </div>
-            </div>
-          </button>
+          <BookmarkAction />
         )}
 
-        {pageType !== "TweetDetails" && (
-          <button
-            onClick={handleIconClick}
-            name="analyze"
-            className="group h-5 min-h-max"
-          >
-            <div className="flex flex-row">
-              <div className="inline-flex relative text-gray-dark group-hover:text-primary-base duration-150">
-                <div className="absolute -m-2 group-hover:bg-primary-hover duration-150 rounded-full top-0 right-0 left-0 bottom-0"></div>
-                <AnalyticsIcon className={"w-5 h-5"} />
-              </div>
-              <div className="inline-flex  group-hover:text-primary-base">
-                <span className="px-3 text-sm">
-                  {formatNumber(tweet?.view)}
-                </span>
-              </div>
-            </div>
-          </button>
-        )}
+        {pageType !== "TweetDetails" && <Views tweet={tweet} />}
 
-        <div
-          className="group h-5 min-h-max relative"
-          role="button"
-          onClick={(e) => {
-            e.stopPropagation();
-            setShowShareMenu(!shareMenu);
-          }}
-        >
-          <div className="flex flex-row group-hover:text-primary-base duration-150">
-            <div className="inline-flex relative ">
-              <div className="absolute -m-2 group-hover:bg-primary-hover duration-150 rounded-full top-0 right-0 left-0 bottom-0 "></div>
-              <ShareIcon className={"w-5 h-5"} />
-            </div>
-          </div>
-          {shareMenu && (
-            <TweetCardComp.ShareMenu
-              onClose={() => setShowShareMenu(false)}
-              tweet={tweet}
-              isAuthenticated={isAuthenticated}
-            />
-          )}
-        </div>
+        <ShareAction isAuthenticated={isAuthenticated} tweet={tweet} />
       </div>
     </div>
   );


### PR DESCRIPTION
This commit introduces a number of improvements to the HomeFeed and TweetActions components:

~ Refactor HomeFeed: To maintain the user's selected feed (ForYouFeed or FollowingFeed) even after a page reload, we added logic to save the 'isForYou' state to localStorage. This ensures that the user experience remains consistent even across page reloads.

~ Refactor TweetActions: The component was normalized to make it more readable and maintainable. This involved breaking down complex structures into simpler, more manageable parts. 

~ Add New Components: New components were introduced as part of the normalization process. These components help to simplify the overall structure of the app and make the codebase more modular and easier to understand.